### PR TITLE
feat: 列表標題中的title從input 改成textarea

### DIFF
--- a/taskify-frontend/src/components/TaskColumn.module.scss
+++ b/taskify-frontend/src/components/TaskColumn.module.scss
@@ -17,7 +17,6 @@
 .titleContainer {
   overflow: visible;
   justify-content: space-between;
-  align-items: center;
   padding: 0 2px;
 }
 
@@ -29,17 +28,19 @@
 
 .taskTitle {
   flex: 2;
-    margin: 0 4px;
+  margin: 0 4px;
   background: transparent;
-  input {
+  textarea {
     background-color: #4592af;
     border: none;
     color: #fff;
-    font-weight: 800;
+    font-size: 1.1rem;
+    font-weight: 600;
     cursor: pointer;
+    border-radius: 8px;
     &:focus {
       color: gray;
-      border: 3px solid #a6e4e7;
+      box-shadow: inset 0 0 0 3px #75e4ea;
       background-color: #f9f5f0;
     }
   }
@@ -48,12 +49,11 @@
 .taskContainer {
   overflow-x: hidden;
   overflow-y: auto;
-  // margin: 4px;
   padding: 2px 4px;
   gap: 8px;
 }
 
 .addButtonContainer {
-padding: 0px 4px;
-    overflow: visible;
+  padding: 0px 4px;
+  overflow: visible;
 }

--- a/taskify-frontend/src/components/TaskColumn.tsx
+++ b/taskify-frontend/src/components/TaskColumn.tsx
@@ -3,15 +3,15 @@ import {
   Button,
   Flex,
   Stack,
-  TextInput,
   ActionIcon,
   Loader,
+  Textarea,
 } from "@mantine/core";
 import style from "@/components/TaskColumn.module.scss";
 import TaskCard from "./TaskCard";
 import NewCardModal from "./NewCardModal";
 import { useState } from "react";
-import { IconDotsVertical } from "@tabler/icons-react";
+import { IconDots } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { fetchBoardData } from "@/api/fetchBoardData";
 import NewBoardModal from "./NewBoardModal";
@@ -209,9 +209,10 @@ function TaskColumn() {
           <Box>
             <Stack className={style.columnContainer}>
               <Flex className={style.titleContainer}>
-                <TextInput
+                <Textarea
                   className={style.taskTitle}
                   defaultValue={column.title}
+                  autosize
                 />
                 <ActionIcon
                   className={style.actionIcon}
@@ -220,7 +221,7 @@ function TaskColumn() {
                   color="white"
                   size={"lg"}
                 >
-                  <IconDotsVertical size="1.125rem" />
+                  <IconDots size="1.125rem" />
                 </ActionIcon>
               </Flex>
               <Stack className={style.taskContainer}>


### PR DESCRIPTION
* 將title從input改成textarea，並將上mantine提供的autosize屬性
* 把border改成box-shadow，因為原本border是none，點擊後變成3px，這樣在畫面上會覺得title的位置有微微的變動，並且在開始打字時，會突然多一個padding
* 將dots的樣式從直的改成橫的