### PR TITLE
fix: navbar的logout按鈕排版、taskboard 的排版

### DIFF
--- a/taskify-frontend/src/components/layout/Navboard.tsx
+++ b/taskify-frontend/src/components/layout/Navboard.tsx
@@ -23,7 +23,7 @@ function NavBoard({ isNavBoardOpen, setIsNavBoardOpen }: Props) {
   return (
     <>
       {isNavBoardOpen ? (
-        <Box p={20} h={"100vh"}>
+        <Stack p={20} h={"100vh"}>
           <Box>
             <Flex justify={"space-between"} align={"center"} mb={20}>
               <Flex className={style.navTitle}>TwoYu</Flex>
@@ -39,7 +39,7 @@ function NavBoard({ isNavBoardOpen, setIsNavBoardOpen }: Props) {
               width={"200px"}
             />
           </Box>
-          <Flex h={"60%"} direction={"column"} justify={"space-between"}>
+          <Flex style={{flex:1}} direction={"column"} justify={"space-between"}>
             <Stack pt={10}>
               <NavLink
                 to="/board"
@@ -88,7 +88,7 @@ function NavBoard({ isNavBoardOpen, setIsNavBoardOpen }: Props) {
               </Button>
             </Flex>
           </Flex>
-        </Box>
+        </Stack>
       ) : (
         <Box w={25}>
           <IconChevronRight

--- a/taskify-frontend/src/pages/Taskboard.tsx
+++ b/taskify-frontend/src/pages/Taskboard.tsx
@@ -4,7 +4,7 @@ import style from "@/pages/Taskboard.module.scss";
 
 function TaskBoard() {
   return (
-    <Stack w={"2000px"} style={{ overflow: "auto hidden" }}>
+    <Stack w={"100%"} style={{ overflow: "auto hidden" }}>
       <Flex className={style.container}>Taskify</Flex>
       <TaskColumn />
     </Stack>


### PR DESCRIPTION
1. navbar logout button 跑版，外層加上display flex來處理
2. TaskBoard上方的工具列跑板問題，寬度設為100%